### PR TITLE
Preserve non-string Option.default across to_json/from_json round-trip

### DIFF
--- a/home_connect_async/appliance.py
+++ b/home_connect_async/appliance.py
@@ -72,7 +72,14 @@ class Option():
     allowedvaluesdisplay:Optional[list[str]] = None
     execution:Optional[str] = None
     liveupdate:Optional[bool] = None
-    default:Optional[str] = None
+    # Annotated `any` (matching `value` above) so dataclass_json won't coerce
+    # the deserialized value to str. The Home Connect API legitimately
+    # returns int / bool / str defaults depending on the option's `type`
+    # (e.g. `BSH.Common.Option.StartInRelative` has `default: 0`, an int);
+    # with `Optional[str]` here the int round-tripped through to_json /
+    # from_json came back as the string "0", silently corrupting cached
+    # config on every load.
+    default:Optional[any] = None
     access:Optional[str] = None
 
     @classmethod


### PR DESCRIPTION
## Summary

`Option.default` is annotated `Optional[str]`, but the Home Connect API legitimately returns mixed types depending on the option's `type` field — e.g. `BSH.Common.Option.StartInRelative` is `type: "Int"` with `default: 0` (integer). `dataclass_json` honours the declared type on deserialisation, so a `to_json` → `from_json` round-trip turns `0` into `"0"`, silently corrupting any code that compares `option.default` to a numeric or boolean value.

This blocks every code path that round-trips cached `HomeConnect` data via `HomeConnect.async_create(json_data=...)`, including the `home-connect-hass` integration's currently-disabled cache.

## Fix

```diff
     execution:Optional[str] = None
     liveupdate:Optional[bool] = None
-    default:Optional[str] = None
+    default:Optional[any] = None
     access:Optional[str] = None
```

`Optional[any]` is consistent with the existing convention used for `Option.value` and `Status.value` — fields whose type is determined at runtime by the appliance's `type` declaration.

I audited the other `Optional[<concrete-type>]` fields on `Option`, `Status`, `Command`, and `Program` to confirm `default` is the only mistyped one. The rest (`displayvalue`, `name`, `unit`, `min`/`max`/`stepsize`, `allowedvalues[display]`, etc.) are correctly typed for their actual API values.

## Test plan

- [x] Offline round-trip spike against 0.8.5 with realistic API-shaped fixtures (full `Option.create()` + `constraints` block): all 5 cases pass with the fix — basic round-trip, empty/None containers, forward-compat with unknown JSON fields, backward-compat with missing optional fields, full constraint preservation. Without the fix, two fail on `default: int → str`.
- [ ] Maintainer-side: `examples/demo.py` round-trip should continue to work.

## Note on the annotation

The lib uses lowercase `any` (the builtin function) rather than `typing.Any` for these fields. I matched the existing style; happy to switch to `typing.Any` if you'd prefer a stricter convention — that would be a wider style change but more correct.

---

*Drafted with Claude Code; reviewed and validated on my running HA install before submission.*
